### PR TITLE
Added support for Date, Time and DateTime objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FormattedTimes
 
-TODO: Write a gem description
+This gem simply overrides the 'method_missing' method of ActiveSupport::TimeWithZone class to provide methods that can be used for getting formatted time stamps. Basically this method uses strftime to get these timestamps.
 
 ## Installation
 
@@ -18,7 +18,93 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+  Once included in your rails application you can use any formatting method that is made out of joining the formatting arguments of strftimes by underscore.
+
+  Any method name for formatting timestamps should start with 'frmt_' and then followed by the options to get time stamp. Following is the option's hash that is used to get strftime methods argument string : 
+
+	      {
+
+	      # Date related options
+
+	      'YY' => '%Y',
+	      'CC' => '%C',
+	      'yy' => '%y',
+	      'mm' => '%m',
+	      'BB' => '%B',
+	      'bb' => '%b',
+	      'hh' => '%h',
+	      'dd' => '%d',
+	      'ee' => '%e',
+	      'jj' => '%j',
+
+	      # Time related options
+
+	      'HH' => '%H',
+	      'kk' => '%k',
+	      'II' => '%I',
+	      'll' => '%l',
+	      'PP' => '%P',
+	      'pp' => '%p',
+	      'MM' => '%M',
+	      'SS' => '%S',
+	      'LL' => '%L',
+	      'NN' => '%N',
+	      '3N' => '%3N',
+	      '6N' => '%6N',
+	      '9N' => '%9N',
+	      '12N' => '%12N',
+
+	      # Time zone related Options
+
+	      'zz' => '%z',
+	      '1z' => '%:z',
+	      '2z' => '%::z',
+	      '3z' => '%:::z',
+	      'ZZ' => '%Z',
+
+	      # Weekday related options
+
+	      'AA' => '%A',
+	      'aa' => '%a',
+	      'uu' => '%u',
+	      'ww' => '%w',
+
+	      # Seconds related opions
+
+	      'ss' => '%s',
+	      'QQ' => '%Q',
+
+	      # Literal string related options
+
+	      'nn' => '%n',
+	      'tt' => '%t',
+
+	      # Combination Options
+
+	      'cc' => '%c',
+	      'DD' => '%D',
+	      'FF' => '%F',
+	      'vv' => '%v',
+	      'xx' => '%x',
+	      'XX' => '%X',
+	      'rr' => '%r',
+	      'RR' => '%R',
+	      'TT' => '%T'
+	    }
+
+  Now if you need date, month and year out of timestamp then you can simply use :
+    
+    User.first.created_at.frmt_dd_mm_yy #=> "27 : 09 : 14"
+
+    # Getting desizered seperator 
+    User.first.created_at.frmt_dd_mm_yy '/' #=> "27/09/14"
+
+    # Some simple usage: 
+    2.1.2 :012 > User.first.created_at.frmt_dd_hh_yy ', '
+    => "27, Sep, 14"
+    2.1.2 :020 > User.first.created_at.frmt_dd_hh_yy_HH_MM_SS
+    => "27 : Sep : 14 : 08 : 44" 
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -26,70 +26,84 @@ Or install it yourself as:
 
 	      # Date related options
 
-	      'YY' => '%Y',
-	      'CC' => '%C',
-	      'yy' => '%y',
-	      'mm' => '%m',
-	      'BB' => '%B',
-	      'bb' => '%b',
-	      'hh' => '%h',
-	      'dd' => '%d',
-	      'ee' => '%e',
-	      'jj' => '%j',
+	      'YY' => '%Y', # Year with century (can be negative, 4 digits at least)
+          				# -0001, 0000, 1995, 2009, 14292, etc.
+	      'CC' => '%C', #  year / 100 (round down.  20 in 2009)
+	      'yy' => '%y', #  year % 100 (00..99)
+	      'mm' => '%m', #  Month of the year, zero-padded (01..12)
+				        # %_m  blank-padded ( 1..12)
+				        # %-m  no-padded (1..12)
+	      'BB' => '%B', #  The full month name (``January'')
+          				# %^B  uppercased (``JANUARY'')
+	      'bb' => '%b', # The abbreviated month name (``Jan'')
+          				# %^b  uppercased (``JAN'')
+	      'hh' => '%h', # Equivalent to %b
+	      'dd' => '%d', # Day of the month, zero-padded (01..31)
+          				# %-d  no-padded (1..31)
+	      'ee' => '%e', # Day of the month, blank-padded ( 1..31)
+	      'jj' => '%j', # Day of the year (001..366)
 
 	      # Time related options
 
-	      'HH' => '%H',
-	      'kk' => '%k',
-	      'II' => '%I',
-	      'll' => '%l',
-	      'PP' => '%P',
-	      'pp' => '%p',
-	      'MM' => '%M',
-	      'SS' => '%S',
-	      'LL' => '%L',
-	      'NN' => '%N',
-	      '3N' => '%3N',
-	      '6N' => '%6N',
-	      '9N' => '%9N',
-	      '12N' => '%12N',
+	      'HH' => '%H', # Hour of the day, 24-hour clock, zero-padded (00..23)
+	      'kk' => '%k', # Hour of the day, 24-hour clock, blank-padded ( 0..23)
+	      'II' => '%I', # Hour of the day, 12-hour clock, zero-padded (01..12)
+	      'll' => '%l', # Hour of the day, 12-hour clock, blank-padded ( 1..12)
+	      'PP' => '%P', # Meridian indicator, lowercase (``am'' or ``pm'')
+	      'pp' => '%p', # Meridian indicator, uppercase (``AM'' or ``PM'')
+	      'MM' => '%M', # Minute of the hour (00..59)
+	      'SS' => '%S', # Second of the minute (00..59)
+	      'LL' => '%L', #  Millisecond of the second (000..999)
+	      'NN' => '%N', # Fractional seconds digits, default is 9 digits (nanosecond)
+	      '3N' => '%3N', # Fractional miliseconds digits, 3 digits
+	      '6N' => '%6N', # Fractional macroseconds digits, 6 digits
+	      '9N' => '%9N', # Fractional nanoseconds digits, 9 digits
+	      '12N' => '%12N', # Fractional picoseconds digits, 12 digits
 
 	      # Time zone related Options
 
-	      'zz' => '%z',
-	      '1z' => '%:z',
-	      '2z' => '%::z',
-	      '3z' => '%:::z',
-	      'ZZ' => '%Z',
+	      'zz' => '%z', # Time zone as hour and minute offset from UTC (e.g. +0900)
+	      '1z' => '%:z', # hour and minute offset from UTC with a colon (e.g. +09:00)
+	      '2z' => '%::z', # hour, minute and second offset from UTC (e.g. +09:00:00)
+	      '3z' => '%:::z', # hour, minute and second offset from UTC (e.g. +09, +09:30, +09:30:30)
+	      'ZZ' => '%Z', # Time zone abbreviation name
 
 	      # Weekday related options
 
-	      'AA' => '%A',
-	      'aa' => '%a',
-	      'uu' => '%u',
-	      'ww' => '%w',
+	      'AA' => '%A', # The full weekday name (``Sunday'')
+          				# %^A  uppercased (``SUNDAY'')
+	      'aa' => '%a', # The abbreviated name (``Sun'')
+          				# %^a  uppercased (``SUN'')
+	      'uu' => '%u', # Day of the week (Monday is 1, 1..7)
+	      'ww' => '%w', # Day of the week (Sunday is 0, 0..6)
+
+	      'GG' => '%G', # The week-based year
+	      'gg' => '%g', # The last 2 digits of the week-based year (00..99)
+	      'VV' => '%V', # Week number of the week-based year (01..53)
+	      'UU' => '%U', # Week number of the year.  The week starts with Sunday.  (00..53)
+	      'WW' => '%W', # Week number of the year.  The week starts with Monday.  (00..53)
 
 	      # Seconds related opions
 
-	      'ss' => '%s',
-	      'QQ' => '%Q',
+	      'ss' => '%s', # Number of seconds since 1970-01-01 00:00:00 UTC.
+	      'QQ' => '%Q', # Number of microseconds since 1970-01-01 00:00:00 UTC.
 
 	      # Literal string related options
 
-	      'nn' => '%n',
-	      'tt' => '%t',
+	      'nn' => '%n', # Newline character (\n)
+	      'tt' => '%t', # Tab character (\t)
 
 	      # Combination Options
 
-	      'cc' => '%c',
-	      'DD' => '%D',
-	      'FF' => '%F',
-	      'vv' => '%v',
-	      'xx' => '%x',
-	      'XX' => '%X',
-	      'rr' => '%r',
-	      'RR' => '%R',
-	      'TT' => '%T'
+	      'cc' => '%c', # date and time (%a %b %e %T %Y)
+	      'DD' => '%D', # Date (%m/%d/%y)
+	      'FF' => '%F', # The ISO 8601 date format (%Y-%m-%d)
+	      'vv' => '%v', # VMS date (%e-%b-%Y)
+	      'xx' => '%x', # Same as %D
+	      'XX' => '%X', # Same as %T
+	      'rr' => '%r', # 12-hour time (%I:%M:%S %p)
+	      'RR' => '%R', # 24-hour time (%H:%M)
+	      'TT' => '%T' # 24-hour time (%H:%M:%S)
 	    }
 
   Now if you need date, month and year out of timestamp then you can simply use :
@@ -105,6 +119,14 @@ Or install it yourself as:
     2.1.2 :020 > User.first.created_at.frmt_dd_hh_yy_HH_MM_SS
     => "27 : Sep : 14 : 08 : 44" 
 
+	# Multiple seperators
+	2.1.2 :002 >  User.first.created_at.frmt_dd_mm_yy(', ', true)
+	=> "27,09 14"
+	2.1.2 :006 >  User.first.created_at.frmt_dd_hh_yy(',-', true)
+	=> "27,Sep-14"
+
+
+Methods from formatted times accepts two arguments a string as seperator and boolean to specify weather given separator is to be used as multiple separator string or single separator string. In case of multiple separator strings the separator strings are devided into character arrays and interleaved into the strftime methods option string.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -113,27 +113,40 @@ Or install it yourself as:
     # Getting desizered seperator
     User.first.created_at.frmt_dd_mm_yy '/' #=> "27/09/14"
 
-    # Some simple usage:
+    # Usage:
     2.1.2 :012 > User.first.created_at.frmt_dd_hh_yy ', '
     => "27, Sep, 14"
     2.1.2 :020 > User.first.created_at.frmt_dd_hh_yy_HH_MM_SS
     => "27 : Sep : 14 : 08 : 44"
 
-	# Multiple seperators
-	2.1.2 :002 >  User.first.created_at.frmt_dd_mm_yy(', ', true)
-	=> "27,09 14"
-	2.1.2 :006 >  User.first.created_at.frmt_dd_hh_yy(',-', true)
-	=> "27,Sep-14"
+    # To format Date object :
+    2.1.2 :002 > Date.today.frmt_dd_mm_yy
+    => "21/06/16"
+
+    # To format datetime object from current timestamp :
+    2.1.2 :007 > Time.now.frmt_dd_hh_yy_HH_MM_SS
+    => "21/Jun/16/13/49/16"
+
+    2.1.2 :003 > DateTime.now.frmt_dd_hh_yy_HH_MM_SS
+    => "21/Jun/16/13/50/16"
+
+
+    # Multiple seperators
+    2.1.2 :002 >  User.first.created_at.frmt_dd_mm_yy(', ', true)
+    => "27,09 14"
+    2.1.2 :006 >  User.first.created_at.frmt_dd_hh_yy(',-', true)
+    => "27,Sep-14"
 
 
 Methods from formatted times accepts two arguments a string as seperator and boolean to specify weather given separator is to be used as multiple separator string or single separator string. In case of multiple separator strings the separator strings are devided into character arrays and interleaved into the strftime methods option string.
 
-Now you can add custom formats with a hash where its key will be the name of the method to call and value will be strftime argument string. Please refer following example:
-  # Custom format definition
-  > FormattedTimes.define_formats({:short_date => '%d %h, %Y'})
-  # after execution of above statement you can use
-  > User.first.created_at.short_date
-  => "18 Nov, 2014"
+Now you can add custom formats with a hash where its key will be the name of the method to call and value will be strftime argument string. Please refer following example.
+
+	#Custom format definition
+	FormattedTimes.define_formats({:short_date => '%d %h, %Y'})
+	#after execution of above statement you can use
+	User.first.created_at.short_date
+	=> "18 Nov, 2014"
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Or install it yourself as:
 
   Once included in your rails application you can use any formatting method that is made out of joining the formatting arguments of strftimes by underscore.
 
-  Any method name for formatting timestamps should start with 'frmt_' and then followed by the options to get time stamp. Following is the option's hash that is used to get strftime methods argument string : 
+  Any method name for formatting timestamps should start with 'frmt_' and then followed by the options to get time stamp. Following is the option's hash that is used to get strftime methods argument string :
 
 	      {
 
@@ -106,18 +106,18 @@ Or install it yourself as:
 	      'TT' => '%T' # 24-hour time (%H:%M:%S)
 	    }
 
-  Now if you need date, month and year out of timestamp then you can simply use :
-    
+  If you need date, month and year out of timestamp then you can simply use :
+
     User.first.created_at.frmt_dd_mm_yy #=> "27 : 09 : 14"
 
-    # Getting desizered seperator 
+    # Getting desizered seperator
     User.first.created_at.frmt_dd_mm_yy '/' #=> "27/09/14"
 
-    # Some simple usage: 
+    # Some simple usage:
     2.1.2 :012 > User.first.created_at.frmt_dd_hh_yy ', '
     => "27, Sep, 14"
     2.1.2 :020 > User.first.created_at.frmt_dd_hh_yy_HH_MM_SS
-    => "27 : Sep : 14 : 08 : 44" 
+    => "27 : Sep : 14 : 08 : 44"
 
 	# Multiple seperators
 	2.1.2 :002 >  User.first.created_at.frmt_dd_mm_yy(', ', true)
@@ -128,9 +128,17 @@ Or install it yourself as:
 
 Methods from formatted times accepts two arguments a string as seperator and boolean to specify weather given separator is to be used as multiple separator string or single separator string. In case of multiple separator strings the separator strings are devided into character arrays and interleaved into the strftime methods option string.
 
+Now you can add custom formats with a hash where its key will be the name of the method to call and value will be strftime argument string. Please refer following example:
+  # Custom format definition
+  > FormattedTimes.define_formats({:short_date => '%d %h, %Y'})
+  # after execution of above statement you can use
+  > User.first.created_at.short_date
+  => "18 Nov, 2014"
+
+
 ## Contributing
 
-1. Fork it ( http://github.com/raviture91/formatted_times/fork )
+1. Fork it ( http://github.com/ravi-ture/formatted_times/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/formatted_times.gemspec
+++ b/formatted_times.gemspec
@@ -8,14 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = FormattedTimes::VERSION
   spec.authors       = ["Ravi-Ture"]
   spec.email         = ["raviture@gmail.com"]
-  spec.summary       = %q{TODO: solve issue of :
-                          2.1.2 :003 > 3.days.from_now
-                            :advance
-                            [{:days=>3}]
-                            ------------------
-                            NoMethodError: undefined method `advance' for Thu, 13 Nov 2014 07:39:03 UTC +00:00:ActiveSupport::TimeWithZone
-                          }
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.summary       = %q{Provides way for clean formatted time stamps}
+  spec.description   = %q{This gem simply overrides the method_missing of ActiveSupport::TimeWithZone module and includes the functionality for responding to various methods that will retrieve a time stamp in required format.}
   spec.homepage      = ""
   spec.license       = "MIT"
 

--- a/formatted_times.gemspec
+++ b/formatted_times.gemspec
@@ -6,7 +6,7 @@ require 'formatted_times/version'
 Gem::Specification.new do |spec|
   spec.name          = "formatted_times"
   spec.version       = FormattedTimes::VERSION
-  spec.authors       = ["Ravi-Ture"]
+  spec.authors       = ["Ravi Ture"]
   spec.email         = ["raviture@gmail.com"]
   spec.summary       = %q{Provides way for clean formatted time stamps}
   spec.description   = %q{This gem simply overrides the method_missing of ActiveSupport::TimeWithZone module and includes the functionality for responding to various methods that will retrieve a time stamp in required format.}
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rails", "~> 2.1.0"
 end

--- a/lib/formatted_times.rb
+++ b/lib/formatted_times.rb
@@ -49,6 +49,11 @@ module ActiveSupport
       'aa' => '%a',
       'uu' => '%u',
       'ww' => '%w',
+      'GG' => '%G',
+      'gg' => '%g',
+      'VV' => '%V',
+      'UU' => '%U',
+      'WW' => '%W',
 
       # Seconds related opions
 
@@ -78,8 +83,8 @@ module ActiveSupport
       method_name = sym.to_s
 
       if method_name.starts_with? 'frmt_'
-        if args.length == 1 and args[0].is_a?(String)
-          strf_time_string = get_strftime_string(method_name, args[0])
+        if args.length.in?([1, 2]) and args[0].is_a?(String)
+          strf_time_string = get_strftime_string(method_name, args[0], args[1])
         else
           strf_time_string = get_strftime_string(method_name)
         end
@@ -91,15 +96,17 @@ module ActiveSupport
       raise e, e.message.sub(time.inspect, self.inspect), e.backtrace
     end
 
-    def get_strftime_string(name, separator=' : ')
+    def get_strftime_string(name, *args)
+      separator = args[0] || ':'
+      multiple_separator=  args[1] || false
       options = name.split('_')
       options.shift
-      invalid_options = options - FORMATTING_OPTIONS.keys
 
+      invalid_options = options - FORMATTING_OPTIONS.keys
       raise ::ArgumentError, "Options #{invalid_options.join(', ')} are invalid." unless invalid_options.empty?
 
-      options.collect{ |option| FORMATTING_OPTIONS[option] }.join(separator)
-
+      strf_options = options.collect{ |option| FORMATTING_OPTIONS[option] }
+      multiple_separator ? strf_options.zip(separator.chars).flatten.compact.join : strf_options.join(separator)
     end
 
   end

--- a/lib/formatted_times.rb
+++ b/lib/formatted_times.rb
@@ -1,4 +1,6 @@
+require "formatted_times/format_time"
 require "formatted_times/active_support_ext"
+require "formatted_times/date_time_ext"
 require "formatted_times/version"
 
 

--- a/lib/formatted_times.rb
+++ b/lib/formatted_times.rb
@@ -3,8 +3,9 @@ require "formatted_times/version"
 
 
 module FormattedTimes
-  def self.define_formats(hash)
-    hash.each do |name, format|
+  def self.define_formats(formats)
+    return false unless formats.is_a? Hash
+    formats.each do |name, format|
       ActiveSupport::TimeWithZone.instance_eval {
         define_method name.to_sym do
           strftime(format)

--- a/lib/formatted_times/active_support_ext.rb
+++ b/lib/formatted_times/active_support_ext.rb
@@ -1,81 +1,7 @@
 
 module ActiveSupport
   class TimeWithZone
-    
-    FORMATTING_OPTIONS = {
-
-      # Date related options
-
-      'YY' => '%Y',
-      'CC' => '%C',
-      'yy' => '%y',
-      'mm' => '%m',
-      'BB' => '%B',
-      'bb' => '%b',
-      'hh' => '%h',
-      'dd' => '%d',
-      'ee' => '%e',
-      'jj' => '%j',
-
-      # Time related options
-
-      'HH' => '%H',
-      'kk' => '%k',
-      'II' => '%I',
-      'll' => '%l',
-      'PP' => '%P',
-      'pp' => '%p',
-      'MM' => '%M',
-      'SS' => '%S',
-      'LL' => '%L',
-      'NN' => '%N',
-      '3N' => '%3N',
-      '6N' => '%6N',
-      '9N' => '%9N',
-      '12N' => '%12N',
-
-      # Time zone related Options
-
-      'zz' => '%z',
-      '1z' => '%:z',
-      '2z' => '%::z',
-      '3z' => '%:::z',
-      'ZZ' => '%Z',
-
-      # Weekday related options
-
-      'AA' => '%A',
-      'aa' => '%a',
-      'uu' => '%u',
-      'ww' => '%w',
-      'GG' => '%G',
-      'gg' => '%g',
-      'VV' => '%V',
-      'UU' => '%U',
-      'WW' => '%W',
-
-      # Seconds related opions
-
-      'ss' => '%s',
-      'QQ' => '%Q',
-
-      # Literal string related options
-
-      'nn' => '%n',
-      'tt' => '%t',
-
-      # Combination Options
-
-      'cc' => '%c',
-      'DD' => '%D',
-      'FF' => '%F',
-      'vv' => '%v',
-      'xx' => '%x',
-      'XX' => '%X',
-      'rr' => '%r',
-      'RR' => '%R',
-      'TT' => '%T'
-    }
+    include FormatTime
 
     def method_missing(sym, *args, &block)
       method_name = sym.to_s
@@ -93,19 +19,5 @@ module ActiveSupport
     rescue NoMethodError => e
       raise e, e.message.sub(time.inspect, self.inspect), e.backtrace
     end
-
-    def get_strftime_string(name, *args)
-      separator = args[0] || ':'
-      multiple_separator=  args[1] || false
-      options = name.split('_')
-      options.shift
-
-      invalid_options = options - FORMATTING_OPTIONS.keys
-      raise ::ArgumentError, "Options #{invalid_options.join(', ')} are invalid." unless invalid_options.empty?
-
-      strf_options = options.collect{ |option| FORMATTING_OPTIONS[option] }
-      multiple_separator ? strf_options.zip(separator.chars).flatten.compact.join : strf_options.join(separator)
-    end
-
   end
 end

--- a/lib/formatted_times/date_time_ext.rb
+++ b/lib/formatted_times/date_time_ext.rb
@@ -1,0 +1,29 @@
+module DateTimeExt
+  include FormatTime
+
+  def method_missing(sym, *args, &block)
+
+    method_name = sym.to_s
+
+    if method_name.starts_with? 'frmt_'
+      if args.length.in?([1, 2]) and args[0].is_a?(String)
+        strf_time_string = get_strftime_string(method_name, args[0], args[1])
+      else
+        strf_time_string = get_strftime_string(method_name)
+      end
+      return self.strftime(strf_time_string)
+    else
+      raise NoMethodError, "undefined method `#{method_name}' for #{self.inspect}:#{self.class.name}"
+    end
+
+  rescue NoMethodError => e
+    raise e, e.message.sub(self.inspect, self.inspect), e.backtrace
+  end
+end
+
+class Date; include DateTimeExt end
+
+class DateTime; include DateTimeExt end
+
+class Time; include DateTimeExt end
+

--- a/lib/formatted_times/format_time.rb
+++ b/lib/formatted_times/format_time.rb
@@ -1,0 +1,90 @@
+module FormatTime
+
+  FORMATTING_OPTIONS = {
+
+    # Date related options
+
+    'YY' => '%Y',
+    'CC' => '%C',
+    'yy' => '%y',
+    'mm' => '%m',
+    'BB' => '%B',
+    'bb' => '%b',
+    'hh' => '%h',
+    'dd' => '%d',
+    'ee' => '%e',
+    'jj' => '%j',
+
+    # Time related options
+
+    'HH' => '%H',
+    'kk' => '%k',
+    'II' => '%I',
+    'll' => '%l',
+    'PP' => '%P',
+    'pp' => '%p',
+    'MM' => '%M',
+    'SS' => '%S',
+    'LL' => '%L',
+    'NN' => '%N',
+    '3N' => '%3N',
+    '6N' => '%6N',
+    '9N' => '%9N',
+    '12N' => '%12N',
+
+    # Time zone related Options
+
+    'zz' => '%z',
+    '1z' => '%:z',
+    '2z' => '%::z',
+    '3z' => '%:::z',
+    'ZZ' => '%Z',
+
+    # Weekday related options
+
+    'AA' => '%A',
+    'aa' => '%a',
+    'uu' => '%u',
+    'ww' => '%w',
+    'GG' => '%G',
+    'gg' => '%g',
+    'VV' => '%V',
+    'UU' => '%U',
+    'WW' => '%W',
+
+    # Seconds related opions
+
+    'ss' => '%s',
+    'QQ' => '%Q',
+
+    # Literal string related options
+
+    'nn' => '%n',
+    'tt' => '%t',
+
+    # Combination Options
+
+    'cc' => '%c',
+    'DD' => '%D',
+    'FF' => '%F',
+    'vv' => '%v',
+    'xx' => '%x',
+    'XX' => '%X',
+    'rr' => '%r',
+    'RR' => '%R',
+    'TT' => '%T'
+  }
+
+  def get_strftime_string(name, *args)
+    separator = args[0] || '/'
+    multiple_separator=  args[1] || false
+    options = name.split('_')
+    options.shift
+
+    invalid_options = options - FORMATTING_OPTIONS.keys
+    raise ::ArgumentError, "Options #{invalid_options.join(', ')} are invalid." unless invalid_options.empty?
+
+    strf_options = options.collect{ |option| FORMATTING_OPTIONS[option] }
+    multiple_separator ? strf_options.zip(separator.chars).flatten.compact.join : strf_options.join(separator)
+  end
+end

--- a/lib/formatted_times/version.rb
+++ b/lib/formatted_times/version.rb
@@ -1,3 +1,3 @@
 module FormattedTimes
-  VERSION = "0.0.1"
+  VERSION = "0.0.3"
 end

--- a/lib/formatted_times/version.rb
+++ b/lib/formatted_times/version.rb
@@ -1,3 +1,3 @@
 module FormattedTimes
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
Added support for Date, Time and DateTime objects, so that the `frmt_dd_mm_yy` methods will also work on  Date, Time and DateTime objects.

Example :

```
Date.today.frmt_dd_mm_yy
DateTime.now.frmt_dd_mm_yy
Time.now.frmt_dd_mm_yy
```
